### PR TITLE
Add Query type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ pub use column::*;
 
 mod types;
 pub use types::*;
+
+pub mod select;

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,447 @@
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Column<T> {
+    pub name: &'static str,
+    pub table: &'static str,
+    pub phantom: std::marker::PhantomData<*const T>,
+}
+
+impl<T> Into<Cow<'static, str>> for &Column<T> {
+    fn into(self) -> Cow<'static, str> {
+        self.name.into()
+    }
+}
+
+pub enum Either<T, E>
+where
+    E: Expr<Datatype = T>,
+{
+    Column {
+        table: Cow<'static, str>,
+        name: Cow<'static, str>,
+        phantom: PhantomData<*const T>,
+    },
+    Expression {
+        expr: E,
+    },
+}
+
+impl<T> Into<Either<T, T>> for Column<T>
+where
+    T: Expr<Datatype = T>,
+{
+    fn into(self) -> Either<T, T> {
+        Either::column(self.table.into(), self.name.into())
+    }
+}
+
+impl<T, E> Either<T, E>
+where
+    E: Expr<Datatype = T>,
+{
+    pub fn column(table: Cow<'static, str>, name: Cow<'static, str>) -> Self {
+        Self::Column {
+            table,
+            name,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn expr(expr: E) -> Self {
+        Self::Expression { expr }
+    }
+}
+
+impl<T, E> Expr for Either<T, E>
+where
+    E: Expr<Datatype = T>,
+{
+    type Datatype = T;
+
+    fn to_sql(&self) -> Cow<'static, str> {
+        match self {
+            Self::Column { table, name, .. } => format!("{}.{}", table, name).into(),
+            Self::Expression { expr } => expr.to_sql(),
+        }
+    }
+}
+
+pub struct Query<E>
+where
+    E: Expr<Datatype = bool>,
+{
+    _prepare: bool,
+    columns: Vec<Cow<'static, str>>,
+    table: Cow<'static, str>,
+    expression: Option<E>,
+    _order_by: Option<Cow<'static, str>>,
+}
+
+impl Query<bool> {
+    pub const NONE: Option<bool> = None;
+}
+
+impl<E> Query<E>
+where
+    E: Expr<Datatype = bool>,
+{
+    pub fn new(
+        _prepare: bool,
+        columns: Vec<Cow<'static, str>>,
+        table: Cow<'static, str>,
+        expression: Option<E>,
+    ) -> Self {
+        Self {
+            _prepare,
+            columns,
+            table,
+            expression,
+            _order_by: None,
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let columns = self.columns.iter().fold(String::new(), |mut acc, col| {
+            if !acc.is_empty() {
+                acc.push_str(", ");
+            }
+            acc.push_str(self.table.as_ref());
+            acc.push('.');
+            acc.push_str(col.as_ref());
+            acc
+        });
+        let expr = if let Some(expr) = self.expression.as_ref() {
+            expr.to_sql().into_owned()
+        } else {
+            String::new()
+        };
+        format!(
+            "SELECT {columns} FROM {table} {_where} {expr}",
+            columns = columns,
+            table = self.table,
+            _where = if self.expression.is_some() {
+                "WHERE"
+            } else {
+                ""
+            },
+            expr = expr
+        )
+    }
+}
+
+pub trait Expr {
+    type Datatype;
+
+    fn to_sql(&self) -> Cow<'static, str>;
+}
+
+macro_rules! impl_base_types {
+    ($t:ty, $to_sql:expr) => {
+        impl Expr for $t {
+            type Datatype = $t;
+            fn to_sql(&self) -> Cow<'static, str> {
+                $to_sql(self).into()
+            }
+        }
+        impl Into<Either<$t, $t>> for $t {
+            fn into(self) -> Either<$t, $t> {
+                Either::expr(self)
+            }
+        }
+    };
+}
+
+impl_base_types!(bool, |&b| if b { "TRUE" } else { "FALSE" });
+impl_base_types!(i32, i32::to_string);
+impl_base_types!(i64, i64::to_string);
+impl_base_types!(String, |s: &String| {
+    let mut tag = std::module_path!()
+        .chars()
+        .filter(char::is_ascii_alphabetic)
+        .collect::<String>();
+    while s.contains(&format!("${}$", &tag)) {
+        tag.extend(
+            std::module_path!()
+                .chars()
+                .filter(char::is_ascii_alphabetic),
+        );
+    }
+    format!("${tag}${}${tag}$", s, tag = tag)
+});
+
+pub struct AndExpression<A, B>
+where
+    A: Expr<Datatype = bool>,
+    B: Expr<Datatype = bool>,
+{
+    left: A,
+    right: B,
+}
+
+impl<A, B> Expr for AndExpression<A, B>
+where
+    A: Expr<Datatype = bool>,
+    B: Expr<Datatype = bool>,
+{
+    type Datatype = bool;
+    fn to_sql(&self) -> Cow<'static, str> {
+        format!("({}) AND ({})", self.left.to_sql(), self.right.to_sql()).into()
+    }
+}
+
+pub struct OrExpression<A, B>
+where
+    A: Expr<Datatype = bool>,
+    B: Expr<Datatype = bool>,
+{
+    left: A,
+    right: B,
+}
+
+impl<A, B> Expr for OrExpression<A, B>
+where
+    A: Expr<Datatype = bool>,
+    B: Expr<Datatype = bool>,
+{
+    type Datatype = bool;
+
+    fn to_sql(&self) -> Cow<'static, str> {
+        format!("({}) OR ({})", self.left.to_sql(), self.right.to_sql()).into()
+    }
+}
+
+pub struct NotExpression<T>
+where
+    T: Expr<Datatype = bool>,
+{
+    expr: T,
+}
+
+impl<T> Expr for NotExpression<T>
+where
+    T: Expr<Datatype = bool>,
+{
+    type Datatype = bool;
+
+    fn to_sql(&self) -> Cow<'static, str> {
+        format!("NOT ({})", self.expr.to_sql()).into()
+    }
+}
+
+pub struct ComparisonExpression<T, L, R>
+where
+    L: Expr<Datatype = T>,
+    R: Expr<Datatype = T>,
+{
+    left: Either<T, L>,
+    right: Either<T, R>,
+    op: Operator,
+    phantom: PhantomData<*const T>,
+}
+
+impl<T, L, R> Expr for ComparisonExpression<T, L, R>
+where
+    L: Expr<Datatype = T>,
+    R: Expr<Datatype = T>,
+{
+    type Datatype = bool;
+
+    fn to_sql(&self) -> Cow<'static, str> {
+        format!(
+            "({}) {} ({})",
+            self.left.to_sql(),
+            self.op,
+            self.right.to_sql()
+        )
+        .into()
+    }
+}
+
+pub enum Operator {
+    LessThan,
+    GreaterThan,
+    LessThanOrEqualTo,
+    GreaterThanOrEqualTo,
+    Equal,
+    NotEqual,
+}
+
+pub struct Where;
+
+impl Where {
+    pub fn and<L, R>(left: L, right: R) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = bool>,
+        R: Expr<Datatype = bool>,
+    {
+        AndExpression { left, right }
+    }
+
+    pub fn or<L, R>(left: L, right: R) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = bool>,
+        R: Expr<Datatype = bool>,
+    {
+        OrExpression { left, right }
+    }
+
+    pub fn not<T>(expr: T) -> impl Expr<Datatype = bool>
+    where
+        T: Expr<Datatype = bool>,
+    {
+        NotExpression { expr }
+    }
+
+    pub fn lt<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::LessThan,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn gt<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::GreaterThan,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn lte<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::LessThanOrEqualTo,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn gte<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::GreaterThanOrEqualTo,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn eq<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::Equal,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn neq<T, L, R>(
+        left: impl Into<Either<T, L>>,
+        right: impl Into<Either<T, R>>,
+    ) -> impl Expr<Datatype = bool>
+    where
+        L: Expr<Datatype = T>,
+        R: Expr<Datatype = T>,
+    {
+        let left = left.into();
+        let right = right.into();
+        ComparisonExpression {
+            left,
+            right,
+            op: Operator::NotEqual,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn column<T>(table: Cow<'static, str>, name: Cow<'static, str>) -> Either<T, T>
+    where
+        T: Expr<Datatype = T>,
+    {
+        Either::Column {
+            table,
+            name,
+            phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn expr<T, E>(expr: E) -> Either<T, E>
+    where
+        E: Expr<Datatype = T>,
+    {
+        Either::Expression { expr }
+    }
+}
+
+impl std::fmt::Display for Operator {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::LessThan => {
+                write!(fmt, "<")
+            }
+            Self::GreaterThan => {
+                write!(fmt, ">")
+            }
+            Self::LessThanOrEqualTo => {
+                write!(fmt, "<=")
+            }
+            Self::GreaterThanOrEqualTo => {
+                write!(fmt, ">=")
+            }
+            Self::Equal => {
+                write!(fmt, "=")
+            }
+            Self::NotEqual => {
+                write!(fmt, "!=")
+            }
+        }
+    }
+}

--- a/tests/basic/testfile.rs
+++ b/tests/basic/testfile.rs
@@ -1,0 +1,119 @@
+use basictest::*;
+use postgres::{Config, NoTls}; //
+
+#[test]
+fn test_test() {
+    let client = &mut Config::new()
+        .user("postgres")
+        .password("postgres")
+        .host("127.0.0.1")
+        .port(5432)
+        .dbname("postgres")
+        .connect(NoTls)
+        .unwrap();
+
+
+    client
+        .batch_execute(
+            r#"CREATE TABLE IF NOT EXISTS accounts (
+        user_id serial PRIMARY KEY,
+        username TEXT UNIQUE NOT NULL,
+        password TEXT NOT NULL,
+        email TEXT UNIQUE NOT NULL,
+        created_on TIMESTAMP NOT NULL,
+        last_login TIMESTAMP
+);"#,
+        )
+        .unwrap();
+    // tabula rasa - clean slate.
+    client.batch_execute(r#"DELETE FROM accounts;
+ALTER SEQUENCE accounts_user_id_seq RESTART;"#).unwrap();
+
+    let created_on = chrono::offset::Local::now().naive_local();
+    let last_login: Option<chrono::naive::NaiveDateTime> = None;
+    let password = "password".to_string();
+    let new_val_1 = AccountsNew {
+        username: "user1",
+        password: &password,
+        email: "foo1@example.com",
+        created_on,
+        last_login,
+    };
+    let new_val_2 = AccountsNew {
+        username: "user2",
+        password: &password,
+        email: "foo2@example.com",
+        created_on,
+        last_login,
+    };
+    let new_val_3 = AccountsNew {
+        username: "user3",
+        password: &password,
+        email: "foo3@example.com",
+        created_on,
+        last_login,
+    };
+    let new_val_4 = AccountsNew {
+        username: "user4",
+        password: &password,
+        email: "foo4@example.com",
+        created_on,
+        last_login,
+    };
+
+    Accounts::insert_slice(client, &[new_val_1, new_val_2, new_val_3, new_val_4]).unwrap();
+
+    for row in client
+        .query("SELECT user_id, username FROM accounts;", &[])
+        .unwrap()
+    {
+        let id: i32 = row.get(0);
+        let name: &str = row.get(1);
+        println!("found person: {} {}", id, name);
+    }
+
+    let _where = Where::gt(Accounts::USER_ID, 1_i32);
+    let q = Query::new(
+        false,
+        vec![
+            "user_id".into(),
+            "username".into(),
+            "password".into(),
+            "email".into(),
+        ],
+        "accounts".into(),
+        Some(_where),
+    );
+    println!("query to string: {}", q.to_string());
+
+    for row in client.query(&q.to_string(), &[]).unwrap() {
+        let id: i32 = row.get(0);
+        let name: &str = row.get(1);
+        println!("found person: {} {}", id, name);
+    }
+
+    let _where1 = Where::gt(Accounts::USER_ID, 1_i32);
+    let _where = Where::and(_where1, Where::eq(Accounts::USERNAME, "user4".to_string()));
+    let q = Query::new(
+        false,
+        vec![
+            "user_id".into(),
+            "username".into(),
+            "password".into(),
+            "email".into(),
+        ],
+        "accounts".into(),
+        Some(_where),
+    );
+    println!("query to string: {}", q.to_string());
+
+    for row in client.query(&q.to_string(), &[]).unwrap() {
+        let id: i32 = row.get(0);
+        let name: &str = row.get(1);
+        println!("found person: {} {}", id, name);
+    }
+
+    // clean up what we did
+    client.batch_execute(r#"DELETE FROM accounts;"#).unwrap();
+
+}


### PR DESCRIPTION
This commit adds a Query type that allows you combine WHERE expressions
with some type checks and generate a postgres query. An `all()` method
is added to the generated table types for conveniently building a
`SELECT` for all table columns and returning the results in a `Vec`.

The `select.rs` module file is self-contained and must be included in generated code.

To see generated code run the `basic` test with `const TMP_DIR: Option<&'static str> = Some("/tmp/basic/");` or some other directory in order to persist the generated code to disk.

```shell
cargo test basic -- --nocapture --ignored
```

An example of a generated SQL query:

```rust
let _where1 = Where::gt(Accounts::USER_ID, 1_i32);
let _where = Where::and(_where1, Where::eq(Accounts::USERNAME, "user4".to_string()));
let q = Query::new(
    /*prepare statement, unused parameter for now */ false,
    /* columns to select */ vec![
        "user_id".into(),
        "username".into(),
        "password".into(),
        "email".into(),
    ],
    /* table to select from */ "accounts".into(),
   /* optional WHERE expression */ Some(_where),
);
assert_eq!(q.to_string(), "SELECT accounts.user_id, accounts.username, accounts.password, accounts.email FROM accounts WHERE ((accounts.user_id) > (1)) AND ((accounts.username) = ($basictest$user4$basictest$))");

for row in client.query(&q.to_string(), &[]).unwrap() {
    let id: i32 = row.get(0);
    let name: &str = row.get(1);
    println!("found person: {} {}", id, name);
}
```

`all()` uses a `TryFrom<postgres::row::Row>` implementation to convert a `Row` result into a Rust type by filling all fields.