### PR TITLE
[WIP] Add SQL query builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# IDEs
+.idea
+
+# Rust
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -290,6 +290,15 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -338,10 +347,11 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "heck",
+ "heck 0.4.0",
  "indexmap",
  "postgres",
  "postgres-types",
+ "sea-query",
  "tempfile",
  "thiserror",
  "time 0.3.9",
@@ -663,6 +673,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sea-query"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a1de9d0334895f7eb51bd1603c3c9f6737413f905a134001f1e198f43bfd70"
+dependencies = [
+ "chrono",
+ "postgres-types",
+ "sea-query-derive",
+ "sea-query-driver",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cdc022b4f606353fe5dc85b09713a04e433323b70163e81513b141c6ae6eb5"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-query-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7f0cae2e7ebb2affc378c40bc343c8197181d601d6755c3e66f1bd18cac253"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +963,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ heck = "0.4.0"
 indexmap = { version = "1.8.2" }
 postgres = { version = "0.19.3", optional = true }
 postgres-types = { version = "0.2.3", features = ["derive"] }
+sea-query = { version = "0.26.3", default-features = false, features = ["backend-postgres", "derive", "with-chrono"] }
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["parsing"] }
-sea-query = { version = "0.26.3", default-features = false, features = ["backend-postgres", "derive", "with-chrono"] }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ heck = "0.4.0"
 indexmap = { version = "1.8.2" }
 postgres = { version = "0.19.3", optional = true }
 postgres-types = { version = "0.2.3", features = ["derive"] }
-sea-query = { version = "0.26.3", default-features = false, features = ["backend-postgres", "derive", "with-chrono"] }
+sea-query = { version = "0.26.3", default-features = false, features = ["backend-postgres", "derive", "with-chrono"], optional = true }
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["parsing"] }
 
@@ -24,4 +24,6 @@ postgres = { version = "0.19.3", features = ["with-chrono-0_4", ] }
 tempfile = "^3.3.0"
 
 [features]
-default = ["postgres", ]
+default = ["postgres", "sql"]
+# Enables SQL query builder functionality.
+sql = ["dep:sea-query"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ postgres = { version = "0.19.3", optional = true }
 postgres-types = { version = "0.2.3", features = ["derive"] }
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["parsing"] }
+sea-query = { version = "0.26.3", default-features = false, features = ["backend-postgres", "derive", "with-chrono"] }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Run tests:
 cargo test -- --nocapture
 ```
 
-## Generate Rust code with the cli
+## Generate Rust code with the CLI
 
 
 ```shell
-cargo run --bin cli --features="postgres clap" -- -t "accounts" > accounts.rs
+cargo run --bin cli --features="postgres clap sql" -- -t "accounts" > accounts.rs
 ```
 
 
 ```shell
-$ cargo run --bin cli --features="postgres clap" -- --help
+$ cargo run --bin cli --features="postgres clap sql" -- --help
 instant-models 0.1.0
 Generate Rust code from postgres table
 
@@ -31,4 +31,80 @@ OPTIONS:
         --pg-username <PG_USERNAME>    Postgres username [default: postgres]
     -t, --table-name <TABLE_NAME>      Name of the table to generate
     -V, --version                      Print version information
+```
+
+## Query Builder
+
+When the `sql` feature is enabled, generated tables include code to compose simple SQL queries.
+
+E.g. Consider the following generated table structure.
+
+```rust
+pub struct Accounts {
+    pub user_id: i32,
+    pub username: String,
+    pub password: String,
+    pub email: String,
+    pub created_on: chrono::naive::NaiveDateTime,
+    pub last_login: Option<chrono::naive::NaiveDateTime>,
+}
+```
+
+We can construct a query to retrieve the username and email address of all users: 
+```rust
+// SELECT "username", "email" FROM "accounts"
+let select: String = Accounts::query()
+    .select(|a| [a.username, a.email])
+    .to_string();
+```
+
+Conditionals can be specified using `filter` and combined using bitwise operators: 
+```rust
+// SELECT "username", "email" FROM "accounts" 
+// WHERE "last_login" IS NOT NULL AND ("user_id" = 1 OR "username" != "admin")
+let select: String = Accounts::query()
+    .select(|a| [a.username, a.email])
+    .filter(|a| Sql::is_not_null(a.last_login) & (Sql::eq(a.user_id, 1) | Sql::ne(a.username, "admin")))
+    .to_string();
+```
+
+### Fetching Queries
+
+With the `postgres` feature enabled, the query can be excuted directly using the [postgres](https://crates.io/crates/postgres) crate:
+
+```rust
+use postgres::{Config, NoTls, Row};
+
+// Connect to a Postgres database.
+let client = &mut Config::new()
+    .user("postgres")
+    .password("postgres")
+    .host("127.0.0.1")
+    .port(5432)
+    .dbname("postgres")
+    .connect(NoTls)
+    .unwrap();
+
+// Fetch all rows.
+let rows: Vec<Row> = Accounts::query()
+    .select(|a| [a.username, a.email])
+    .fetch(client, &[])
+    .unwrap();
+```
+
+## Development
+
+
+### Tests
+
+Start a local, ephemeral Postgres instance:
+
+```bash
+docker run -it -p 127.0.0.1:5432:5432 --rm -e POSTGRES_PASSWORD=postgres postgres
+```
+
+Run all tests:
+
+```bash
+cargo test
 ```

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -45,4 +45,6 @@ fn main() {
     println!("{}", struct_bldr.build_type());
     println!("\n{}", struct_bldr.build_new_type());
     println!("\n{}", struct_bldr.build_type_methods());
+    #[cfg(feature = "sql")]
+    println!("\n{}", struct_bldr.build_field_identifiers());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
-mod struct_builder;
+pub use column::*;
 pub use struct_builder::*;
+pub use sql::*;
+pub use types::*;
 
 mod column;
-pub use column::*;
-
+mod struct_builder;
+mod sql;
 mod types;
-pub use types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub use column::*;
-pub use struct_builder::*;
+#[cfg(feature = "sql")]
 pub use sql::*;
+pub use struct_builder::*;
 pub use types::*;
 
 mod column;
-mod struct_builder;
+#[cfg(feature = "sql")]
 mod sql;
+mod struct_builder;
 mod types;

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,5 +1,5 @@
-mod table;
 mod query;
+mod table;
 
-pub use table::*;
 pub use query::*;
+pub use table::*;

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,0 +1,5 @@
+mod table;
+mod query;
+
+pub use table::*;
+pub use query::*;

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1,0 +1,157 @@
+use std::marker::PhantomData;
+use sea_query::JoinType;
+use crate::{Combine, Sources, Table};
+
+pub struct SqlQuery<T: ?Sized> {
+    sources: PhantomData<T>,
+    // TODO: replace SelectStatement with something custom.
+    query: sea_query::SelectStatement,
+}
+
+// TODO: replace sea_query::Iden with something custom.
+impl<T: Sources + ?Sized> SqlQuery<T> {
+    pub fn new() -> SqlQuery<T> {
+        let mut query = sea_query::SelectStatement::new();
+        for table in T::tables() {
+            query.from(table);
+        }
+        Self {
+            query,
+            sources: PhantomData::<T>,
+        }
+    }
+
+    pub fn select<F, C, I>(mut self, columns: F) -> Self
+        where
+            F: FnOnce(T::SOURCES) -> I,
+            C: sea_query::IntoColumnRef,
+            I: IntoIterator<Item = C>,
+    {
+        self.query.columns(columns(T::sources()));
+        self
+    }
+
+    pub fn where_<F>(mut self, conditions: F) -> Self
+        where
+            F: FnOnce(T::SOURCES) -> Sql,
+    {
+        self.query.cond_where(conditions(T::sources()).cond);
+        self
+    }
+
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.query.limit(limit);
+        self
+    }
+
+    pub fn to_string(&self) -> String {
+        self.query.to_string(sea_query::PostgresQueryBuilder)
+    }
+}
+
+impl<S: Sources> SqlQuery<S> {
+    fn from<T: Table>(mut self) -> SqlQuery<S::COMBINED>
+        where
+            S: Combine<T>,
+    {
+        self.query.from(T::table());
+        SqlQuery {
+            sources: PhantomData::<S::COMBINED>,
+            query: self.query,
+        }
+    }
+
+    fn join<T: Table>(mut self) -> SqlQuery<S::COMBINED>
+        where
+            // TODO: restrict join to only tables with foreign keys.
+            S: Combine<T>,
+    {
+        // TODO: join on foreign keys, or add them to a list and handle them on .finish()/whatever.
+        // self.query.join(JoinType::Join, T::table(), );
+        SqlQuery {
+            sources: PhantomData::<S::COMBINED>,
+            query: self.query,
+        }
+    }
+}
+
+/// SQL condition for e.g. WHERE, ON, HAVING clauses.
+///
+/// Can be composed using bitwise operators `&` for AND, `|` for OR.
+pub struct Sql {
+    // TODO: replace sea_query.
+    cond: sea_query::Cond,
+}
+
+impl Sql {
+    pub fn eq<T, V>(col: T, value: V) -> Self
+        where
+            T: sea_query::IntoColumnRef,
+            V: Into<sea_query::Value>,
+    {
+        Self {
+            cond: sea_query::Cond::all().add(sea_query::Expr::col(col).eq(value)),
+        }
+    }
+
+    pub fn equals<T, U, V>(left: T, table: U, right: V) -> Self
+        where
+            T: sea_query::IntoColumnRef,
+            U: sea_query::IntoIden,
+            V: sea_query::IntoIden,
+    {
+        Self {
+            cond: sea_query::Cond::all().add(sea_query::Expr::col(left).equals(table, right)),
+        }
+    }
+
+    pub fn ne<T, V>(col: T, value: V) -> Self
+        where
+            T: sea_query::IntoColumnRef,
+            V: Into<sea_query::Value>,
+    {
+        Self {
+            cond: sea_query::Cond::all().add(sea_query::Expr::col(col).ne(value)),
+        }
+    }
+
+    pub fn is_null<T>(col: T) -> Self
+        where
+            T: sea_query::IntoColumnRef,
+    {
+        Self {
+            cond: sea_query::Cond::all().add(sea_query::Expr::col(col).is_null()),
+        }
+    }
+
+    pub fn is_not_null<T>(col: T) -> Self
+        where
+            T: sea_query::IntoColumnRef,
+    {
+        Self {
+            cond: sea_query::Cond::all().add(sea_query::Expr::col(col).is_not_null()),
+        }
+    }
+
+    // TODO: port rest of conditions.
+}
+
+impl std::ops::BitAnd for Sql {
+    type Output = Sql;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Sql {
+            cond: sea_query::Cond::all().add(self.cond).add(rhs.cond),
+        }
+    }
+}
+
+impl std::ops::BitOr for Sql {
+    type Output = Sql;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Sql {
+            cond: sea_query::Cond::any().add(self.cond).add(rhs.cond),
+        }
+    }
+}

--- a/src/sql/table.rs
+++ b/src/sql/table.rs
@@ -1,0 +1,90 @@
+use crate::SqlQuery;
+
+pub trait Table {
+    // TODO: replace sea_query.
+    type Fields;
+
+    fn query() -> SqlQuery<Self> {
+        SqlQuery::new()
+    }
+
+    /// Returns a reference to the table definition.
+    fn table() -> sea_query::TableRef;
+
+    /// Returns a struct with the SQL column definitions.
+    fn fields() -> Self::Fields;
+}
+
+/// Represents one or more SQL [Table].
+pub trait Sources {
+    type SOURCES;
+
+    fn sources() -> Self::SOURCES;
+
+    /// List of all tables currently referenced in the query.
+    fn tables() -> Vec<sea_query::TableRef>;
+}
+
+impl<T: Table + ?Sized> Sources for T {
+    type SOURCES = T::Fields;
+
+    fn sources() -> Self::SOURCES {
+        T::fields()
+    }
+
+    fn tables() -> Vec<sea_query::TableRef> {
+        use sea_query::IntoTableRef;
+        vec![T::table().into_table_ref()]
+    }
+}
+
+/// Helper trait for combining tuples of SQL table field definitions.
+///
+/// E.g.
+/// - A + B => (A,B).
+/// - (A,B) + C => (A,B,C).
+pub trait Combine<O> {
+    type COMBINED;
+}
+
+impl<A: Table + 'static, B: Table + 'static> Combine<B> for A {
+    type COMBINED = (A, B);
+}
+
+macro_rules! impl_sources_tuple {
+    ( $( $name:ident )+ ) => {
+        impl<$($name: Table + 'static),+> Sources for ($($name,)+)
+        {
+            type SOURCES = ($($name::Fields,)+);
+
+            fn sources() -> Self::SOURCES {
+                ($($name::fields(),)+)
+            }
+
+            fn tables() -> Vec<sea_query::TableRef> {
+                use sea_query::IntoTableRef;
+                vec![$($name::table().into_table_ref(),)+]
+            }
+        }
+    };
+    ( $( $name:ident )+, $joinable:expr ) => {
+        impl_sources_tuple!($($name)+);
+
+        impl<Z: Table + 'static, $($name: Table + 'static),+> Combine<Z> for ($($name,)+) {
+            type COMBINED = ($($name,)+ Z);
+        }
+    };
+}
+
+// Implement Sources for tuples of tables: (A,), (A,B), (A,B,C), etc.
+// If you want to join more than ten tables in a single query, open an issue.
+impl_sources_tuple! { A, true }
+impl_sources_tuple! { A B, true }
+impl_sources_tuple! { A B C, true }
+impl_sources_tuple! { A B C D, true }
+impl_sources_tuple! { A B C D E, true }
+impl_sources_tuple! { A B C D E F, true }
+impl_sources_tuple! { A B C D E F G, true }
+impl_sources_tuple! { A B C D E F G H, true }
+impl_sources_tuple! { A B C D E F G H I, true }
+impl_sources_tuple! { A B C D E F G H I J }

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -1,244 +1,24 @@
-#![allow(dead_code)]
-
-use postgres::{Config, NoTls};
-use sea_query::{ConditionalStatement, JoinType, PostgresQueryBuilder, Query};
-use std::fmt::Write;
-use std::marker::PhantomData;
 use instant_models::{Sql, Table};
+use postgres::{Config, NoTls};
 
 // Example generated with
 // `cargo run --bin cli --features="postgres clap" -- -t "accounts" > accounts.rs`
-//
 
 pub struct Accounts {
     pub user_id: i32,
+    pub created_on: chrono::naive::NaiveDateTime,
+    pub last_login: Option<chrono::naive::NaiveDateTime>,
     pub username: String,
     pub password: String,
     pub email: String,
-    pub created_on: chrono::naive::NaiveDateTime,
-    pub last_login: Option<chrono::naive::NaiveDateTime>,
 }
 
 pub struct AccountsNew<'a> {
+    pub created_on: chrono::naive::NaiveDateTime,
+    pub last_login: Option<chrono::naive::NaiveDateTime>,
     pub username: &'a str,
     pub password: &'a str,
     pub email: &'a str,
-    pub created_on: chrono::naive::NaiveDateTime,
-    pub last_login: Option<chrono::naive::NaiveDateTime>,
-}
-
-pub struct Access {
-    pub user: i32,
-    pub domain: i32,
-    pub role: String,
-}
-
-#[derive(sea_query::Iden, Copy, Clone)]
-pub enum AccessIden {
-    Table,
-    User,
-    Domain,
-    Role,
-}
-
-pub struct AccessFields {
-    pub table: AccessIden,
-    pub user: AccessIden,
-    pub domain: AccessIden,
-    pub role: AccessIden,
-}
-
-pub const ACCESS_FIELDS: AccessFields = AccessFields {
-    table: AccessIden::Table,
-    user: AccessIden::User,
-    domain: AccessIden::Domain,
-    role: AccessIden::Role,
-};
-
-pub struct Example {
-    pub id: i32,
-    pub example: String,
-}
-
-#[derive(sea_query::Iden, Copy, Clone)]
-pub enum ExampleIden {
-    Table,
-    Id,
-    Example,
-}
-
-pub struct ExampleFields {
-    pub table: ExampleIden,
-    pub id: ExampleIden,
-    pub example: ExampleIden,
-}
-
-pub const EXAMPLE_FIELDS: ExampleFields = ExampleFields {
-    table: ExampleIden::Table,
-    id: ExampleIden::Id,
-    example: ExampleIden::Example,
-};
-
-// TODO: derive this automatically.
-#[derive(Copy, Clone)]
-pub enum AccountsIden {
-    Table,
-    UserId,
-    Username,
-    Password,
-    Email,
-    CreatedOn,
-    LastLogin,
-}
-
-impl sea_query::Iden for AccountsIden {
-    fn unquoted(&self, s: &mut dyn Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "accounts",
-                Self::UserId => "user_id",
-                Self::Username => "username",
-                Self::Password => "password",
-                Self::Email => "email",
-                Self::CreatedOn => "created_on",
-                Self::LastLogin => "last_login",
-            }
-        )
-        .expect("AccountsIden failed to write");
-    }
-}
-
-impl Table for Accounts {
-    type Fields = AccountsFields;
-}
-
-impl Table for Access {
-    type Fields = AccessFields;
-}
-
-impl Table for Example {
-    type Fields = ExampleFields;
-}
-
-pub trait IdenFields: sea_query::Iden {
-    type Fields;
-
-    fn table() -> Self;
-    fn fields() -> Self::Fields;
-}
-
-impl IdenFields for AccountsIden {
-    type Fields = AccountsFields;
-
-    fn table() -> Self {
-        AccountsIden::Table
-    }
-
-    fn fields() -> Self::Fields {
-        ACCOUNTS_FIELDS
-    }
-}
-
-impl IdenFields for AccessIden {
-    type Fields = AccessFields;
-
-    fn table() -> Self {
-        AccessIden::Table
-    }
-
-    fn fields() -> Self::Fields {
-        ACCESS_FIELDS
-    }
-}
-
-impl IdenFields for ExampleIden {
-    type Fields = ExampleFields;
-
-    fn table() -> Self {
-        ExampleIden::Table
-    }
-
-    fn fields() -> Self::Fields {
-        EXAMPLE_FIELDS
-    }
-}
-
-
-
-pub struct AccountsFields {
-    pub user_id: AccountsIden,
-    pub username: AccountsIden,
-    pub password: AccountsIden,
-    pub email: AccountsIden,
-    pub created_on: AccountsIden,
-    pub last_login: AccountsIden,
-}
-
-pub const ACCOUNTS_FIELDS: AccountsFields = AccountsFields {
-    user_id: AccountsIden::UserId,
-    username: AccountsIden::Username,
-    password: AccountsIden::Password,
-    email: AccountsIden::Email,
-    created_on: AccountsIden::CreatedOn,
-    last_login: AccountsIden::LastLogin,
-};
-
-// // TODO: derive this automatically
-// impl AccountsIden {
-//     pub fn eq(self, value: impl Into<sea_query::Value>) -> Sql {
-//         Sql::eq(self, value)
-//     }
-//
-//     pub fn ne(self, value: impl Into<sea_query::Value>) -> Sql {
-//         Sql::ne(self, value)
-//     }
-//
-//     pub fn is_not_null(self) -> Sql {
-//         Sql::is_not_null(self)
-//     }
-//
-// }
-
-
-#[test]
-fn test_sea_query() {
-    let expected = r#"SELECT "user_id", "username", "password", "email"
-FROM "accounts", "access", "example"
-WHERE "username" = 'foo'
-    AND ("last_login" IS NOT NULL OR "created_on" <> '1970-01-01 00:00:00')
-    AND ("user_id" = "access"."user" AND "role" = 'DomainAdmin')
-    AND "user_id" = "example"."id"
-"#;
-
-    let user = "foo";
-    let role = "DomainAdmin";
-    let timestamp = chrono::NaiveDateTime::from_timestamp(0, 0);
-
-    let query = Accounts::query()
-        .select(|a| [a.user_id, a.username, a.password, a.email])
-        .where_(|a| {
-            Sql::eq(a.username, user)
-                & (Sql::is_not_null(a.last_login) | a.created_on.ne(timestamp))
-        })
-        .from::<Access>()
-        .where_(|(a, acl)| Sql::equals(a.user_id, acl.table, acl.user) & Sql::eq(acl.role, role))
-        .join::<Example>()
-        .where_(|(a, .., ex)| Sql::equals(a.user_id, ex.table, ex.id))
-        .to_string();
-
-    assert_eq!(query, expected.replace('\n', " "));
-    // let row = sqlx::query!(query)
-    //   .fetch_one(&pool)
-    //   .await?;
-
-    // TODO: custom trait/s to simplify query/statement execution ergonomics, so they
-    //       can be called immediately with, e.g. `.fetch_one(&pool)?`, rather than two steps,
-    //       and without the `PostgresQueryBuilder`?
-
-    // TODO: how to use prepared statements to avoid SQL injection?
-    //       https://github.com/SeaQL/sea-query/issues/22
 }
 
 impl Accounts {
@@ -246,18 +26,16 @@ impl Accounts {
         client: &mut postgres::Client,
         slice: &[AccountsNew<'_>],
     ) -> Result<(), postgres::Error> {
-        let statement = client.prepare(
-            "INSERT INTO accounts(username, password, email, created_on, last_login) VALUES($1, $2, $3, $4, $5);",
-        )?;
+        let statement = client.prepare("INSERT INTO accounts(created_on, last_login, username, password, email) VALUES($1, $2, $3, $4, $5);")?;
         for entry in slice {
             client.execute(
                 &statement,
                 &[
+                    &entry.created_on,
+                    &entry.last_login,
                     &entry.username,
                     &entry.password,
                     &entry.email,
-                    &entry.created_on,
-                    &entry.last_login,
                 ],
             )?;
         }
@@ -265,8 +43,64 @@ impl Accounts {
     }
 }
 
+#[derive(Copy, Clone)]
+pub enum AccountsIden {
+    Table,
+    UserId,
+    CreatedOn,
+    LastLogin,
+    Username,
+    Password,
+    Email,
+}
+
+impl sea_query::Iden for AccountsIden {
+    fn unquoted(&self, s: &mut dyn std::fmt::Write) {
+        write!(
+            s,
+            "{}",
+            match self {
+                Self::Table => "accounts",
+                Self::UserId => "user_id",
+                Self::CreatedOn => "created_on",
+                Self::LastLogin => "last_login",
+                Self::Username => "username",
+                Self::Password => "password",
+                Self::Email => "email",
+            }
+        )
+        .expect("AccountsIden failed to write");
+    }
+}
+
+pub struct AccountsFields {
+    pub user_id: AccountsIden,
+    pub created_on: AccountsIden,
+    pub last_login: AccountsIden,
+    pub username: AccountsIden,
+    pub password: AccountsIden,
+    pub email: AccountsIden,
+}
+
+impl instant_models::Table for Accounts {
+    type FieldsType = AccountsFields;
+    const FIELDS: Self::FieldsType = AccountsFields {
+        user_id: AccountsIden::UserId,
+        created_on: AccountsIden::CreatedOn,
+        last_login: AccountsIden::LastLogin,
+        username: AccountsIden::Username,
+        password: AccountsIden::Password,
+        email: AccountsIden::Email,
+    };
+
+    fn table() -> sea_query::TableRef {
+        use sea_query::IntoTableRef;
+        AccountsIden::Table.into_table_ref()
+    }
+}
+
 #[test]
-fn test_accounts() {
+fn test_accounts_insert() {
     let client = &mut Config::new()
         .user("postgres")
         .password("postgres")
@@ -325,10 +159,13 @@ fn test_accounts() {
 
     Accounts::insert_slice(client, &[new_val_1, new_val_2, new_val_3, new_val_4]).unwrap();
 
-    for row in client
-        .query("SELECT user_id, username FROM accounts;", &[])
-        .unwrap()
-    {
+    let select_query = Accounts::query().select(|a| [a.user_id, a.username]);
+    assert_eq!(
+        select_query.to_string(),
+        r#"SELECT "user_id", "username" FROM "accounts""#
+    );
+
+    for row in select_query.fetch(client, &[]).unwrap() {
         let id: i32 = row.get(0);
         let name: &str = row.get(1);
         println!("found person: {} {}", id, name);
@@ -336,4 +173,62 @@ fn test_accounts() {
 
     // clean up what we did
     client.batch_execute(r#"DELETE FROM accounts;"#).unwrap();
+}
+
+#[test]
+fn test_accounts_query() {
+    // SELECT single column.
+    let select = Accounts::query().select(|a| [a.user_id]).to_string();
+    assert_eq!(select, r#"SELECT "user_id" FROM "accounts""#);
+
+    // SELECT multiple columns.
+    let select_multiple = Accounts::query()
+        .select(|a| [a.user_id, a.username, a.email])
+        .to_string();
+    assert_eq!(
+        select_multiple,
+        r#"SELECT "user_id", "username", "email" FROM "accounts""#
+    );
+
+    // SELECT WHERE single condition.
+    let select_where = Accounts::query()
+        .select(|a| [a.user_id])
+        .filter(|a| Sql::is_null(a.last_login))
+        .to_string();
+    assert_eq!(
+        select_where,
+        r#"SELECT "user_id" FROM "accounts" WHERE "last_login" IS NULL"#
+    );
+
+    // SELECT WHERE AND.
+    let select_where_and = Accounts::query()
+        .select(|a| [a.user_id])
+        .filter(|a| Sql::is_null(a.last_login) & Sql::is_not_null(a.created_on))
+        .to_string();
+    assert_eq!(
+        select_where_and,
+        r#"SELECT "user_id" FROM "accounts" WHERE "last_login" IS NULL AND "created_on" IS NOT NULL"#
+    );
+
+    // SELECT WHERE OR.
+    let select_where_or = Accounts::query()
+        .select(|a| [a.user_id])
+        .filter(|a| Sql::is_null(a.last_login) | Sql::is_not_null(a.created_on))
+        .to_string();
+    assert_eq!(
+        select_where_or,
+        r#"SELECT "user_id" FROM "accounts" WHERE "last_login" IS NULL OR "created_on" IS NOT NULL"#
+    );
+
+    // SELECT WHERE AND OR.
+    let select_where_and_or = Accounts::query()
+        .select(|a| [a.user_id])
+        .filter(|a| {
+            Sql::is_null(a.last_login) & (Sql::is_not_null(a.created_on) | Sql::eq(a.user_id, 1))
+        })
+        .to_string();
+    assert_eq!(
+        select_where_and_or,
+        r#"SELECT "user_id" FROM "accounts" WHERE "last_login" IS NULL AND ("created_on" IS NOT NULL OR "user_id" = 1)"#
+    );
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -28,6 +28,8 @@ fn create_cargo_project(builder: StructBuilder) -> Result<(), anyhow::Error> {
     file.write_all(builder.build_type().as_bytes())?;
     file.write_all(builder.build_new_type().as_bytes())?;
     file.write_all(builder.build_type_methods().as_bytes())?;
+    #[cfg(feature = "sql")]
+    file.write_all(builder.build_field_identifiers().as_bytes())?;
     drop(file);
     let mut manifest_file = OpenOptions::new()
         .write(true)

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -1,0 +1,229 @@
+use instant_models::{Sql, Table};
+use sea_query::TableRef;
+use std::fmt::Write;
+
+// Example manually constructed.
+
+pub struct Accounts {
+    pub user_id: i32,
+    pub created_on: chrono::naive::NaiveDateTime,
+    pub last_login: Option<chrono::naive::NaiveDateTime>,
+    pub username: String,
+    pub password: String,
+    pub email: String,
+}
+
+pub struct AccountsNew<'a> {
+    pub created_on: chrono::naive::NaiveDateTime,
+    pub last_login: Option<chrono::naive::NaiveDateTime>,
+    pub username: &'a str,
+    pub password: &'a str,
+    pub email: &'a str,
+}
+
+impl Accounts {
+    pub fn insert_slice(
+        client: &mut postgres::Client,
+        slice: &[AccountsNew<'_>],
+    ) -> Result<(), postgres::Error> {
+        let statement = client.prepare("INSERT INTO accounts(created_on, last_login, username, password, email) VALUES($1, $2, $3, $4, $5);")?;
+        for entry in slice {
+            client.execute(
+                &statement,
+                &[
+                    &entry.created_on,
+                    &entry.last_login,
+                    &entry.username,
+                    &entry.password,
+                    &entry.email,
+                ],
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum AccountsIden {
+    Table,
+    UserId,
+    CreatedOn,
+    LastLogin,
+    Username,
+    Password,
+    Email,
+}
+
+impl sea_query::Iden for AccountsIden {
+    fn unquoted(&self, s: &mut dyn std::fmt::Write) {
+        write!(
+            s,
+            "{}",
+            match self {
+                Self::Table => "accounts",
+                Self::UserId => "user_id",
+                Self::CreatedOn => "created_on",
+                Self::LastLogin => "last_login",
+                Self::Username => "username",
+                Self::Password => "password",
+                Self::Email => "email",
+            }
+        )
+        .expect("AccountsIden failed to write");
+    }
+}
+
+pub struct AccountsFields {
+    pub user_id: AccountsIden,
+    pub created_on: AccountsIden,
+    pub last_login: AccountsIden,
+    pub username: AccountsIden,
+    pub password: AccountsIden,
+    pub email: AccountsIden,
+}
+
+impl instant_models::Table for Accounts {
+    type FieldsType = AccountsFields;
+    const FIELDS: Self::FieldsType = AccountsFields {
+        user_id: AccountsIden::UserId,
+        created_on: AccountsIden::CreatedOn,
+        last_login: AccountsIden::LastLogin,
+        username: AccountsIden::Username,
+        password: AccountsIden::Password,
+        email: AccountsIden::Email,
+    };
+
+    fn table() -> sea_query::TableRef {
+        use sea_query::IntoTableRef;
+        AccountsIden::Table.into_table_ref()
+    }
+}
+
+pub struct Access {
+    pub user: i32,
+    pub domain: i32,
+    pub role: String,
+}
+
+#[derive(Copy, Clone)]
+pub enum AccessIden {
+    Table,
+    User,
+    Domain,
+    Role,
+}
+
+impl sea_query::Iden for AccessIden {
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(
+            s,
+            "{}",
+            match self {
+                Self::Table => "access",
+                Self::User => "user",
+                Self::Domain => "domain",
+                Self::Role => "role",
+            }
+        )
+        .expect("AccessIden failed to write");
+    }
+}
+
+pub struct AccessFields {
+    pub table: AccessIden,
+    pub user: AccessIden,
+    pub domain: AccessIden,
+    pub role: AccessIden,
+}
+
+impl Table for Access {
+    type FieldsType = AccessFields;
+    const FIELDS: Self::FieldsType = AccessFields {
+        table: AccessIden::Table,
+        user: AccessIden::User,
+        domain: AccessIden::Domain,
+        role: AccessIden::Role,
+    };
+
+    fn table() -> TableRef {
+        use sea_query::IntoTableRef;
+        AccessIden::Table.into_table_ref()
+    }
+}
+
+pub struct Examples {
+    pub id: i32,
+    pub example: String,
+}
+
+#[derive(Copy, Clone)]
+pub enum ExamplesIden {
+    Table,
+    Id,
+    Example,
+}
+
+pub struct ExamplesFields {
+    pub table: ExamplesIden,
+    pub id: ExamplesIden,
+    pub example: ExamplesIden,
+}
+
+impl sea_query::Iden for ExamplesIden {
+    fn unquoted(&self, s: &mut dyn Write) {
+        write!(
+            s,
+            "{}",
+            match self {
+                Self::Table => "examples",
+                Self::Id => "id",
+                Self::Example => "example",
+            }
+        )
+        .expect("ExampleIden failed to write");
+    }
+}
+
+impl Table for Examples {
+    type FieldsType = ExamplesFields;
+    const FIELDS: Self::FieldsType = ExamplesFields {
+        table: ExamplesIden::Table,
+        id: ExamplesIden::Id,
+        example: ExamplesIden::Example,
+    };
+
+    fn table() -> TableRef {
+        use sea_query::IntoTableRef;
+        ExamplesIden::Table.into_table_ref()
+    }
+}
+
+#[test]
+fn test_query_join() {
+    let expected = r#"SELECT "user_id", "username", "password", "email"
+FROM "accounts", "access", "examples"
+WHERE "username" = 'foo'
+AND ("last_login" IS NOT NULL OR "created_on" <> '1970-01-01 00:00:00')
+AND ("user_id" = "access"."user" AND "role" = 'DomainAdmin')
+AND "user_id" = "examples"."id"
+LIMIT 1"#;
+
+    let user = "foo";
+    let role = "DomainAdmin";
+    let timestamp = chrono::NaiveDateTime::from_timestamp(0, 0);
+
+    let query = Accounts::query()
+        .filter(|a| {
+            Sql::eq(a.username, user)
+                & (Sql::is_not_null(a.last_login) | Sql::ne(a.created_on, timestamp))
+        })
+        .from::<Access>()
+        .filter(|(a, acl)| Sql::equals(a.user_id, acl.table, acl.user) & Sql::eq(acl.role, role))
+        .from::<Examples>()
+        .filter(|(a, .., ex)| Sql::equals(a.user_id, ex.table, ex.id))
+        .select(|(a, ..)| [a.user_id, a.username, a.password, a.email])
+        .limit(1)
+        .to_string();
+
+    assert_eq!(query, expected.replace('\n', " "));
+}


### PR DESCRIPTION
## Description

Implements a proof-of-concept SQL query builder. Currently only supports basic `SELECT` statements with a few conditionals, and uses the [sea-query](https://github.com/SeaQL/sea-query) crate to compose and generate SQL for now (can be replaced later once the top-level API is finalised).

This attempts to match the syntax from https://github.com/InstantDomain/instant-models/pull/4#discussion_r934443932.

### Example

1. Select a subset of columns.

```sql
SELECT "username", "email" FROM "accounts"
```

```rust
let select: String = Accounts::query()
    .select(|a| [a.username, a.email])
    .to_string();
```

2. Select and filter from multiple tables.

```sql
SELECT "user_id", "username", "password", "email"
FROM "accounts", "access", "examples"
WHERE "username" = 'foo'
AND ("last_login" IS NOT NULL OR "created_on" <> '1970-01-01 00:00:00')
AND ("user_id" = "access"."user" AND "role" = 'DomainAdmin')
AND "user_id" = "examples"."id"
LIMIT 1
```

```rust
let query = Accounts::query()
    .from::<Access>()
    .from::<Examples>()
    .filter(|(a, ..)| {
        Sql::eq(a.username, user)
            & (Sql::is_not_null(a.last_login) | Sql::ne(a.created_on, timestamp))
    })
    .filter(|(a, acl, ..)| Sql::equals(a.user_id, acl.table, acl.user) & Sql::eq(acl.role, role))
    .filter(|(a, .., ex)| Sql::equals(a.user_id, ex.table, ex.id))
    .select(|(a, ..)| [a.user_id, a.username, a.password, a.email])
    .limit(1)
    .to_string();
```

The filters could also be combined into one using `&` instead of multiple `filter`s.

3. Execute the query using the [postgres](https://crates.io/crates/postgres) crate:

```rust
let rows: Vec<postgres::Row> = Accounts::query()
    .select(|a| [a.username, a.email])
    .fetch(&mut client, &[])
    .unwrap();
```

Other feature flags could be added for different runtimes.

### TODO

- [ ] Implement `join` (automatic `ON` clause generation with foreign keys).
- [ ] Restrict `join` clauses at compile-time to tables with foreign keys.
- [ ] Support `SELECT *` for all columns.
- [ ] Use a derive proc-macro to defer generating field identifier boilerplate (`AccountsFields`, `AccountsIden`, `impl Table for Accounts`, etc.)?
- [ ] Implement SQL conditionals (`eq`, `ne`, `like`, etc.) .
- [ ] Implement SQL keywords (DISTINCT, ORDER BY, etc.).
- [ ] Replace `sea-query`?

### Problems

The big problem currently is being unable to restrict which tables can join each other at runtime, due to how the `Sources` trait is set up to operate on tuples of tables. 

E.g.

1. Generics don't work without negative trait bounds,
```rust
impl<A,B> Join<Accounts> for (A, B)
where A: Join<Accounts> {
    type JOINED = (A, B, Accounts);
```
since trying to implement the same for B causes a "conflicting trait implementation" compilation error.

```rust
impl<A,B> Join<Accounts> for (A, B)
where B: Join<Accounts> {
    type JOINED = (A, B, Accounts);
```

2. Implementing the trait over concrete types for each permutation works, but requires a combinatorial explosion of code to be generated manually for each possible table combination that can be joined:

```rust
// E.g. Access can be joined to Accounts.
impl Join<Accounts> for (Access, Example) {
    type JOINED = (Access, Example, Accounts);
}

// Every other permutation and combination with Access in it needs to be joinable too.
impl Join<Accounts> for (Example, Access) ...
impl Join<Accounts> for (Access, Other) ...
impl Join<Accounts> for (Other, Access) ...
impl Join<Accounts> for (Acesss, Example, Other) ... // combinations have to be implemented for each tuple size too.
```

## Type of change

Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added unit tests. See the README.md for instructions.
